### PR TITLE
Component.isMounted() is deprecated

### DIFF
--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -82,8 +82,13 @@ export const BaseMixin = sessionGetter => ({
     update(this, this.props, this.state);
   },
 
+  componentDidMount() {
+    this._rethinkMixinState.isMounted = true;
+  },
+
   componentWillUnmount() {
     unmount(this);
+    this._rethinkMixinState.isMounted = false;
   },
 
   componentWillUpdate(nextProps, nextState) {

--- a/src/util.js
+++ b/src/util.js
@@ -18,7 +18,7 @@ export const ensure = (value, msg) => {
 export const updateComponent = component => {
   // Check for document because of this bug:
   // https://github.com/facebook/react/issues/3620
-  if (component.isMounted() && typeof document !== 'undefined') {
+  if (component._rethinkMixinState.isMounted && typeof document !== 'undefined') {
     component.forceUpdate();
   }
 };


### PR DESCRIPTION
Fix for isMounted. It's totally broken on latest React using ES6 classes.