### PR TITLE
Adds QueryRequest Post-Transforms

### DIFF
--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -18,7 +18,7 @@ const update = (component, props, state) => {
   Object.keys(observed).forEach(key => {
     const queryRequest = observed[key];
     const oldSubscription = subscriptions[key];
-    const queryResult = component.data[key] || new QueryResult(queryRequest.initial);
+    const queryResult = component.data[key] || new QueryResult(queryRequest.initial, queryRequest.transform);
     subscriptions[key] = subscriptionManager.subscribe(component, queryRequest, queryResult);
     component.data[key] = queryResult;
     if (oldSubscription) {

--- a/src/QueryRequest.js
+++ b/src/QueryRequest.js
@@ -6,10 +6,11 @@ import {normalizeQueryEncoding} from './util';
 // for the API.
 //
 // QueryRequests have have 3 required properties.
-// * query:   the RethinkDB query to run
-// * changes: boolean specifying whether to subscribe to the realtime
-//            changefeed too
-// * initial: value to be returned before the query finishes loading
+// * query:     the RethinkDB query to run
+// * changes:   boolean specifying whether to subscribe to the realtime
+//              changefeed too
+// * initial:   value to be returned before the query finishes loading
+// * transform: function applied after the query finishes loading
 //
 // Here is a simple example of an QueryRequest that a component might use in
 // its observe() function:
@@ -17,12 +18,19 @@ import {normalizeQueryEncoding} from './util';
 //     query: r.table('turtles'),
 //     changes: true,
 //     initial: [],
+//     transform: (rows) => { // array-to-object, using id as key for O(1) lookup
+//       rows.reduce((prev, cur) => {
+//        prev[cur.id] = cur
+//        prev
+//      }, {})
+//    }
 //   })
 export class QueryRequest {
-  constructor({query, changes, initial}) {
+  constructor({query, changes, initial, transform}) {
     this.query = normalizeQueryEncoding(query);
     this.changes = changes;
     this.initial = initial;
+    this.transform = transform;
   }
 
   // Convert the QueryRequest into a string that can be used as a

--- a/src/QueryResult.js
+++ b/src/QueryResult.js
@@ -6,7 +6,8 @@
 // QueryResults are available in this.data for components that use the
 // provided mixin. See Mixin.js for the API.
 export class QueryResult {
-  constructor(initialValue) {
+  constructor(initialValue, transform) {
+    this._transform = transform;
     this._initialValue = initialValue;
     this._unresetValue = undefined;
     this._value = undefined;
@@ -50,11 +51,14 @@ export class QueryResult {
   // query results may seem inconsistent with the rest of the view. Using the
   // loading() method in the UI should help.
   value({allowStaleQuery = false} = {}) {
-    if (allowStaleQuery) {
-      return this._loadingInitial ? this._initialValue : this._unresetValue;
-    } else {
-      return this._loading ? this._initialValue : this._value;
-    }
+    const value = allowStaleQuery
+      ? (this._loadingInitial // allows stale queries
+        ? this._initialValue
+        : this._unresetValue)
+      : (this._loading // ...does not
+        ? this._initialValue
+        : this._value);
+    return this._transform ? this._transform(value) : value;
   }
 
   // Return true if we are waiting to receive the query results from the


### PR DESCRIPTION

Hey Mike!  Maybe you've run into the problem where augmenting data to a QueryResult is a cleaner solution (data everything) than sprinkling code inside React components; or, perhaps that a more complex RethinkDB query isn't streamable with changes, eg:

r.table("online")
  .group('id')
  .ungroup()
  .map([r.row('group'), r.row('reduction')])
  .coerceTo('object')
  .changes()

What I am doing instead is using a more simple, streamable query and then transforming the result on the client after it's received:

r.table('online').changes()

...and then something like:

       transform: (rows) => { // array-to-object, using id as key for O(1) lookup
         rows.reduce((prev, cur) => {
          prev[cur.id] = cur
          prev
        }, {})

This pull-request adds support for transforms.  Please let me know your thoughts; I wanted to supply code demonstrating the idea rather than an issue.

Keith