### PR TITLE
Catch error w/ callback, dependency update, ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "rethinkdb-websocket-client": "^0.4.7"
+    "rethinkdb-websocket-client": "^0.5.1"
   },
   "devDependencies": {
     "babel": "^5.5.6",


### PR DESCRIPTION
catch errors w/ optional callback function, use console.log instead of console.warn for RN

dependency update