### PR TITLE
Pass wsBinaryType to the websocket-client

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -35,10 +35,10 @@ export const MetaSession = RethinkdbWebsocketClient => {
       this._subscriptionManager = new SubscriptionManager(runQueryFn);
     }
 
-    connect({host, port, path, wsProtocols, secure, db, simulatedLatencyMs, autoReconnectDelayMs}) {
+    connect({host, port, path, wsProtocols, wsBinaryType, secure, db, simulatedLatencyMs, autoReconnectDelayMs}) {
       ensure(!this._connPromise, 'Session.connect() called when connected');
       const connectAfterDelay = delayMs => {
-        const options = {host, port, path, wsProtocols, secure, db, simulatedLatencyMs};
+        const options = {host, port, path, wsProtocols, wsBinaryType, secure, db, simulatedLatencyMs};
         this._connPromise = new Promise((resolve, reject) => {
           setTimeout(() => {
             connect(options).then(resolve, reject);


### PR DESCRIPTION
Pass 'wsBinaryType' to the client, related to https://github.com/mikemintz/rethinkdb-websocket-client/pull/21